### PR TITLE
getTodaysTrends endpoint and remove getPoints

### DIFF
--- a/lib/WelbeDesc.js
+++ b/lib/WelbeDesc.js
@@ -125,18 +125,18 @@ module.exports = {
     url: "/users/{{userId}}/saving-types/todays-savings",
     note: "return values not mapped, but they contain the saving_type_ids"
   },
-  getPoints: {
+  getTodaysTrends: {
     method: "get",
     desc: "Retrieve point and rank info",
-    url: "/v2/users/{{userId}}/points",
+    url: "/trends/today",
     returns: {
-      counts: {
-        type: "hash",
-        desc: "counts for 'today', 'calendar_week', 'calendar_month', 'year_to_date' and 'life_time'"
+      days: {
+        type: "array",
+        desc: "object with 'date', 'percent_of_goal_met', 'weighted_percent_of_goal_met', 'pillars' (object), 'logs', and 'message'"
       },
-      rolling_28_days: {
+      rollup: {
         type: "hash",
-        desc: "rolling 28 stats for 'welbe_rank', 'daily_average', 'weekly_average' and 'difference_between_today_and_daily_average'"
+        desc: "total_logs, 'pillars' (object), 'percent_of_goal_met', and 'weighted_percent_of_goal_met'"
       },
     }
   },


### PR DESCRIPTION
getPoints no longer works

getTodaysTrends is useful if you wish to
check if you have logged meals, etc

test plan:
- `welbe getTodaysTrends` should return something like:

```
{ days:
   [ { date: '2016-04-29',
       percent_of_goal_met: 0,
       weighted_percent_of_goal_met: 0,
       pillars: [Object],
       logs: 0,
       message: 'Only 64 ounces of water to meet the goal' } ],
  rollup:
   { total_logs: 0,
     pillars:
      { activity: [Object],
        body_metrics: [Object],
        meals: [Object],
        savings: [Object],
        sleep: [Object],
        water: [Object] },
     percent_of_goal_met: 0,
     weighted_percent_of_goal_met: 0 } }
```
